### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,3 +14,10 @@ queue_rules:
     allow_queue_branch_edit: true
     update_method: merge
     name: default
+merge_protections:
+  - name: Do not merge outdated PRs
+    description: Make sure PRs are almost up to date before merging
+    if:
+      - base = main
+    success_conditions:
+      - "#commits-behind <= 10"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,8 @@ name: Deploy to GitHub Pages
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
 permissions:
   contents: write
   pages: write


### PR DESCRIPTION
This change has been made by @MH0386 from the Mergify merge protections editor.

## Summary by Sourcery

CI:
- Add a Mergify rule named “Do not merge outdated PRs” to require PRs be within 10 commits of main before merging